### PR TITLE
Update Nokogiri, pin `logger` and document supported local Jekyll setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 # Jekyll theme
 gem "minimal-mistakes-jekyll"
+gem "logger", "~> 1.5.3"
 
 gem "jekyll-paginate", group: :jekyll_plugins
 gem "github-pages", group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,7 +210,9 @@ GEM
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.5.3)
     mercenary (0.3.6)
+    mini_portile2 (2.8.9)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
@@ -224,7 +226,10 @@ GEM
       jekyll-sitemap (~> 1.3)
     minitest (5.14.4)
     multipart-post (2.1.1)
-    nokogiri (1.11.3-x86_64-linux)
+    nokogiri (1.18.10)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
     octokit (4.21.0)
       faraday (>= 0.9)
@@ -232,7 +237,7 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
-    racc (1.5.2)
+    racc (1.8.1)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -274,6 +279,7 @@ DEPENDENCIES
   github-pages
   jekyll-include-cache
   jekyll-paginate
+  logger (~> 1.5.3)
   minimal-mistakes-jekyll
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@
 
 ### Prerequisites
 
-- Ruby 3.1 or earlier
+- Ruby 3.1
 - Bundler
 - An available UTF-8 locale
 
-This dependency set does not support Ruby 3.2 or later because Liquid 4.0.3
-calls APIs that Ruby 3.2 removed.
+Ruby 3.1 is the only supported Ruby release for this dependency set. Nokogiri
+1.18.10 requires Ruby 3.1 or later, while Liquid 4.0.3 calls APIs that Ruby 3.2
+removed.
 
 Install the locked dependencies from the repository root:
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-The blog of Adisakshya Chauhan
+# Adisakshya Chauhan's blog
+
+## Local development
+
+### Prerequisites
+
+- Ruby 3.1 or earlier
+- Bundler
+- An available UTF-8 locale
+
+This dependency set does not support Ruby 3.2 or later because Liquid 4.0.3
+calls APIs that Ruby 3.2 removed.
+
+Install the locked dependencies from the repository root:
+
+```sh
+bundle install
+```
+
+### Build the site
+
+Jekyll must run under a UTF-8 locale to compile the site's Sass assets. For
+example, if your operating system provides the locale as `C.utf8`, run:
+
+```sh
+LANG=C.utf8 bundle exec jekyll build
+```
+
+The exact UTF-8 locale name is operating-system dependent. Check the locales
+available on your system (for example, with `locale -a`) and set `LANG` to an
+available UTF-8 locale. If your shell already uses one, the usual build command
+is sufficient:
+
+```sh
+bundle exec jekyll build
+```
+
+The generated site is written to `_site/`.
+
+### Serve the site
+
+Start Jekyll's local development server under an available UTF-8 locale:
+
+```sh
+LANG=C.utf8 bundle exec jekyll serve
+```
+
+When the shell already uses a UTF-8 locale, use:
+
+```sh
+bundle exec jekyll serve
+```


### PR DESCRIPTION
### Motivation

- Prevent Jekyll 3.9.0 from resolving to a newer, incompatible `logger` by adding a direct `logger` runtime pin. 
- Bring `nokogiri` and the transitive gems it requires up-to-date so native extensions build cleanly on modern platforms under Ruby 3.1. 
- Capture the project's local-development prerequisites and workflows, and record the required UTF-8-locale and supported Ruby range to avoid subtle Sass/Liquid/runtime failures. 

### Description

- Added `gem "logger", "~> 1.5.3"` to `Gemfile` so the runtime `logger` used by Jekyll 3.9 remains in the Ruby 3.1-compatible 1.5 series. 
- Ran `bundle lock --update nokogiri` under Ruby 3.1 and updated `Gemfile.lock` to record `nokogiri 1.18.10`, `mini_portile2 2.8.9`, and `racc 1.8.1`, while keeping `github-pages 214`, `jekyll 3.9.0`, `minimal-mistakes-jekyll 4.22.0`, and `liquid 4.0.3` unchanged. 
- Added the direct `logger (~> 1.5.3)` entry under `DEPENDENCIES` in `Gemfile.lock`. 
- Expanded `README.md` with a “Local development” section documenting prerequisites (Ruby 3.1 or earlier, Bundler, UTF-8 locale), and the commands `bundle install`, `LANG=C.utf8 bundle exec jekyll build`, `bundle exec jekyll build`, and `LANG=C.utf8 bundle exec jekyll serve` (with notes that the exact `LANG` value is OS-dependent). 
- Committed the changes as the working change set titled `Update Nokogiri and document supported local Jekyll setup`.

### Testing

- `LANG=C.utf8 mise exec ruby@3.1.6 -- bundle _2.2.24_ lock --update nokogiri` completed successfully and wrote the updated `Gemfile.lock`. 
- `LANG=C.utf8 mise exec ruby@3.1.6 -- bundle _2.2.24_ install` completed successfully (97 gems installed) under Ruby `3.1.6` and Bundler `2.2.24`. 
- `rm -rf _site && LANG=C.utf8 mise exec ruby@3.1.6 -- bundle _2.2.24_ exec jekyll build` succeeded and produced `_site/` containing 45 files. 
- `env -u LANG -u LC_ALL -u LC_CTYPE mise exec ruby@3.1.6 -- bundle _2.2.24_ exec jekyll build` failed as expected with `Invalid US-ASCII character "\xE2"`, confirming the documented Sass/UTF-8 locale constraint; `bundle check` and `git diff --check` also passed.