### PR TITLE
Add .devcontainer configuration for GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "Weblog",
+  "image": "mcr.microsoft.com/devcontainers/jekyll:0-bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "forwardPorts": [4000],
+  "portsAttributes": {
+    "4000": {
+      "label": "Jekyll server",
+      "onAutoForward": "openPreview"
+    }
+  },
+  "postCreateCommand": "bundle install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Shopify.theme-check-vscode"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #50.

GitHub Codespaces couldn't initialize for this repo because there was no `.devcontainer` configuration. This adds `.devcontainer/devcontainer.json` so Codespaces knows how to set up the Jekyll environment.

- Base image: `mcr.microsoft.com/devcontainers/jekyll:0-bullseye` (Ruby + Jekyll + build tools)
- `postCreateCommand: "bundle install"` to auto-install gems on container creation
- `Shopify.theme-check-vscode` VSCode extension for theme development
- `git` and `github-cli` devcontainer features
- Forwards port `4000` and auto-opens a preview when `jekyll serve` starts

## Review notes

There was already a candidate fix on `add-devcontainer-config`. I reviewed it:
- It's based on the current `master` (one commit ahead, cleanly mergeable — verified with `git merge-base --is-ancestor`).
- I ran `bundle install` locally against this repo's `Gemfile`/`Gemfile.lock` to confirm the `postCreateCommand` actually succeeds (97 gems installed, no errors).

The config was otherwise correct, so I carried it over and added one small improvement: `forwardPorts`/`portsAttributes` for port 4000, so `bundle exec jekyll serve` gets an automatic Codespaces preview instead of requiring the port to be forwarded manually.

## Test plan

- [x] Validated `.devcontainer/devcontainer.json` is valid JSON
- [x] Verified `bundle install` succeeds against the repo's `Gemfile.lock`
- [ ] Open a Codespace on this branch and confirm it initializes and `bundle exec jekyll serve` works with the auto-forwarded preview


---
_Generated by [Claude Code](https://claude.ai/code/session_015VtVGMK64QZMJCHUah8qkf)_